### PR TITLE
Log out old sessions if indicated; compare tz-aware datetimes

### DIFF
--- a/django_force_logout/middleware.py
+++ b/django_force_logout/middleware.py
@@ -1,5 +1,6 @@
 import time
 import datetime
+import pytz
 
 from django.contrib import auth
 
@@ -34,10 +35,18 @@ class ForceLogoutMiddleware(object):
                 request.session[self.SESSION_KEY],
             )
         except KeyError:
-            # May not have logged in since we started populating this key.
-            return
-
-        if timestamp > user_timestamp:
-            return
+            # May not have logged in since we started populating this key.  If
+            # so, and the logout timestamp is set, we're supposed to log out
+            # this user.
+            pass
+        else:
+            try:
+                if timestamp > user_timestamp:
+                    return
+            except TypeError:
+                import pytz
+                utctimestamp = pytz.utc.localize(timestamp)
+                if utctimestamp > user_timestamp:
+                    return
 
         auth.logout(request)

--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,6 @@ setup(
 
     install_requires=(
         'Django>=1.8',
+        'pytz>=2016',
     ),
 )


### PR DESCRIPTION
Two changes here:

1. If an session was created before the middleware was installed AND the user has a non-NULL logout time, they should be logged out.
2. If comparison fails, try again with a tz-aware datetime.