### PR TITLE
Ensure get_response is assigned to self, by calling the superclass

### DIFF
--- a/django_force_logout/middleware.py
+++ b/django_force_logout/middleware.py
@@ -24,6 +24,8 @@ class ForceLogoutMiddleware(MiddlewareMixin):
     SESSION_KEY = 'force-logout:last-login'
 
     def __init__(self, get_response=None):
+        super(ForceLogoutMiddleware, self).__init__(get_response)
+
         self.fn = app_settings.CALLBACK
 
         if not callable(self.fn):


### PR DESCRIPTION
Fixes a bug where the Middleware is not quite Django 2.0 compatible. Under Django 2.0, one gets an exception that looks like:
`AttributeError: 'ForceLogoutMiddleware' object has no attribute 'get_response'`

This is because the `MiddlewareMixin` does [this](https://github.com/django/django/blob/master/django/utils/deprecation.py#L87)
and `ForceLogoutMiddleware` doesn't call `super`.